### PR TITLE
Add production backend-url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -57,7 +57,10 @@
     {% if jekyll.environment == "local" %}
     const BACKEND_BASE_URL = "http://localhost:3000/";
     const FRONTEND_BASE_URL = "http://localhost:4000/"
-    {% else %}
+    {% elsif jekyll.environment == "production" %}
+    const BACKEND_BASE_URL = "http://138.68.86.108:2000/";
+    const FRONTEND_BASE_URL = "http://localhost:4000/"
+	{% else %}
     const BACKEND_BASE_URL = "https://pure-inlet-98383.herokuapp.com/";
     const FRONTEND_BASE_URL = "https://ohtukisalli.github.io/"
     {% endif %}


### PR DESCRIPTION
Lisäsin tuotannolle oman jekyll.environmentin.
Meidän backendi pyörii nyt tosiaan tuolla http://138.68.86.108:2000/

Pitääköhän vielä muualle lisätä noita env-juttuja, että kaikki toimii?
Mulla ei nyt toiminut esimerkiksi scoreboardin katselu, mutta se vaikutti backendin ongelmalta.